### PR TITLE
fix: add SetWriteDeadline on conn.Write

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -33,10 +33,10 @@ type Conn struct {
 // NewConn is called to create a new connection.
 func NewConn(ctx context.Context, conn net.Conn, msgBuffSize int, writeDeadline time.Duration) *Conn {
 	c := &Conn{
-		reader: make(chan []byte, msgBuffSize),
-		writer: make(chan []byte, msgBuffSize),
-
-		conn: conn,
+		reader:        make(chan []byte, msgBuffSize),
+		writer:        make(chan []byte, msgBuffSize),
+		writeDeadline: writeDeadline,
+		conn:          conn,
 	}
 
 	c.ctx, c.cancel = context.WithCancel(ctx)

--- a/examples/acceptor/main.go
+++ b/examples/acceptor/main.go
@@ -3,6 +3,10 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"net"
+	"strconv"
+	"time"
+
 	simplefixgo "github.com/b2broker/simplefix-go"
 	"github.com/b2broker/simplefix-go/fix"
 	"github.com/b2broker/simplefix-go/fix/encoding"
@@ -10,9 +14,6 @@ import (
 	"github.com/b2broker/simplefix-go/session/messages"
 	"github.com/b2broker/simplefix-go/session/storages/memory"
 	fixgen "github.com/b2broker/simplefix-go/tests/fix44"
-	"net"
-	"strconv"
-	"time"
 )
 
 func mustConvToInt(s string) int {
@@ -69,7 +70,7 @@ func main() {
 
 	handlerFactory := simplefixgo.NewAcceptorHandlerFactory(fixgen.FieldMsgType, 10)
 
-	server := simplefixgo.NewAcceptor(listener, handlerFactory, func(handler simplefixgo.AcceptorHandler) {
+	server := simplefixgo.NewAcceptor(listener, handlerFactory, time.Second*5, func(handler simplefixgo.AcceptorHandler) {
 		sess, err := session.NewAcceptorSession(
 			&pseudoGeneratedOpts,
 			handler,

--- a/examples/initiator/main.go
+++ b/examples/initiator/main.go
@@ -4,6 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
+	"strconv"
+	"time"
+
 	simplefixgo "github.com/b2broker/simplefix-go"
 	"github.com/b2broker/simplefix-go/fix"
 	"github.com/b2broker/simplefix-go/fix/encoding"
@@ -11,9 +15,6 @@ import (
 	"github.com/b2broker/simplefix-go/session/messages"
 	fixgen "github.com/b2broker/simplefix-go/tests/fix44"
 	"github.com/b2broker/simplefix-go/utils"
-	"net"
-	"strconv"
-	"time"
 )
 
 func mustConvToInt(s string) int {
@@ -70,7 +71,7 @@ func main() {
 	defer cancel()
 
 	handler := simplefixgo.NewInitiatorHandler(ctx, fixgen.FieldMsgType, 10)
-	client := simplefixgo.NewInitiator(conn, handler, 10)
+	client := simplefixgo.NewInitiator(conn, handler, 10, time.Second*5)
 
 	handler.OnConnect(func() bool {
 		return true

--- a/initiator.go
+++ b/initiator.go
@@ -3,9 +3,11 @@ package simplefixgo
 import (
 	"context"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"net"
 	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // InitiatorHandler is an interface implementing basic methods required for handling the Initiator object.
@@ -27,11 +29,11 @@ type Initiator struct {
 }
 
 // NewInitiator creates a new Initiator instance.
-func NewInitiator(conn net.Conn, handler InitiatorHandler, bufSize int) *Initiator {
+func NewInitiator(conn net.Conn, handler InitiatorHandler, bufSize int, writeDeadline time.Duration) *Initiator {
 	c := &Initiator{handler: handler}
 	c.ctx, c.cancel = context.WithCancel(context.Background())
 
-	c.conn = NewConn(c.ctx, conn, bufSize)
+	c.conn = NewConn(c.ctx, conn, bufSize, writeDeadline)
 
 	return c
 }

--- a/tests/acceptor.go
+++ b/tests/acceptor.go
@@ -2,12 +2,13 @@ package tests
 
 import (
 	"fmt"
-	simplefixgo "github.com/b2broker/simplefix-go"
-	"github.com/b2broker/simplefix-go/session"
-	fixgen "github.com/b2broker/simplefix-go/tests/fix44"
 	"net"
 	"testing"
 	"time"
+
+	simplefixgo "github.com/b2broker/simplefix-go"
+	"github.com/b2broker/simplefix-go/session"
+	fixgen "github.com/b2broker/simplefix-go/tests/fix44"
 )
 
 func RunAcceptor(port int, t *testing.T, storage session.MessageStorage) (acceptor *simplefixgo.Acceptor, addr string) {
@@ -18,7 +19,7 @@ func RunAcceptor(port int, t *testing.T, storage session.MessageStorage) (accept
 
 	handlerFactory := simplefixgo.NewAcceptorHandlerFactory(fixgen.FieldMsgType, 10)
 
-	server := simplefixgo.NewAcceptor(listener, handlerFactory, func(handler simplefixgo.AcceptorHandler) {
+	server := simplefixgo.NewAcceptor(listener, handlerFactory, time.Minute*50, func(handler simplefixgo.AcceptorHandler) {
 		s, err := session.NewAcceptorSession(
 			&pseudoGeneratedOpts,
 			handler,

--- a/tests/acceptor_initiator_test.go
+++ b/tests/acceptor_initiator_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/b2broker/simplefix-go/fix/encoding"
 	"net"
 	"regexp"
 	"strconv"
@@ -13,6 +12,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/b2broker/simplefix-go/fix/encoding"
 
 	simplefixgo "github.com/b2broker/simplefix-go"
 	"github.com/b2broker/simplefix-go/fix"
@@ -87,7 +88,7 @@ func TestGroup(t *testing.T) {
 
 	handlerFactory := simplefixgo.NewAcceptorHandlerFactory(fixgen.FieldMsgType, 10)
 
-	acceptor := simplefixgo.NewAcceptor(listener, handlerFactory, func(handler simplefixgo.AcceptorHandler) {
+	acceptor := simplefixgo.NewAcceptor(listener, handlerFactory, time.Second*5, func(handler simplefixgo.AcceptorHandler) {
 		s, err := session.NewAcceptorSession(
 			&pseudoGeneratedOpts,
 			handler,
@@ -326,7 +327,7 @@ func TestCloseInitiatorConn(t *testing.T) {
 
 	waitClientClosed := make(chan struct{})
 	handlerFactory := simplefixgo.NewAcceptorHandlerFactory(fixgen.FieldMsgType, 10)
-	server := simplefixgo.NewAcceptor(listener, handlerFactory, func(handler simplefixgo.AcceptorHandler) {
+	server := simplefixgo.NewAcceptor(listener, handlerFactory, time.Second*5, func(handler simplefixgo.AcceptorHandler) {
 		s, err := session.NewAcceptorSession(
 			&pseudoGeneratedOpts,
 			handler,
@@ -365,7 +366,7 @@ func TestCloseInitiatorConn(t *testing.T) {
 	}
 
 	handler := simplefixgo.NewInitiatorHandler(context.Background(), fixgen.FieldMsgType, 10)
-	client := simplefixgo.NewInitiator(conn, handler, 10)
+	client := simplefixgo.NewInitiator(conn, handler, 10, time.Second*5)
 
 	s, err := session.NewInitiatorSession(
 		handler,
@@ -411,7 +412,7 @@ func TestCloseAcceptorConn(t *testing.T) {
 
 	waitServerDisconnect := make(chan struct{})
 	handlerFactory := simplefixgo.NewAcceptorHandlerFactory(fixgen.FieldMsgType, 10)
-	server := simplefixgo.NewAcceptor(listener, handlerFactory, func(handler simplefixgo.AcceptorHandler) {
+	server := simplefixgo.NewAcceptor(listener, handlerFactory, time.Second*5, func(handler simplefixgo.AcceptorHandler) {
 		s, err := session.NewAcceptorSession(
 			&pseudoGeneratedOpts,
 			handler,
@@ -450,7 +451,7 @@ func TestCloseAcceptorConn(t *testing.T) {
 	}
 
 	initiatorHandler := simplefixgo.NewInitiatorHandler(context.Background(), fixgen.FieldMsgType, 10)
-	client := simplefixgo.NewInitiator(conn, initiatorHandler, 10)
+	client := simplefixgo.NewInitiator(conn, initiatorHandler, 10, time.Second*5)
 
 	s, err := session.NewInitiatorSession(
 		initiatorHandler,
@@ -506,7 +507,7 @@ func TestLookAtClosingOfInitiator(t *testing.T) {
 
 	waitClientDisconnect := make(chan struct{})
 	handlerFactory := simplefixgo.NewAcceptorHandlerFactory(fixgen.FieldMsgType, 10)
-	server := simplefixgo.NewAcceptor(listener, handlerFactory, func(handler simplefixgo.AcceptorHandler) {
+	server := simplefixgo.NewAcceptor(listener, handlerFactory, time.Second*5, func(handler simplefixgo.AcceptorHandler) {
 		acceptorSession, err := session.NewAcceptorSession(
 			&pseudoGeneratedOpts,
 			handler,
@@ -560,7 +561,7 @@ func TestLookAtClosingOfInitiator(t *testing.T) {
 	}
 
 	initiatorHandler := simplefixgo.NewInitiatorHandler(context.Background(), fixgen.FieldMsgType, 10)
-	client := simplefixgo.NewInitiator(conn, initiatorHandler, 10)
+	client := simplefixgo.NewInitiator(conn, initiatorHandler, 10, time.Second*5)
 
 	initiatorSession, err := session.NewInitiatorSession(
 		initiatorHandler,
@@ -610,7 +611,7 @@ func TestInterruptHandling(t *testing.T) {
 
 	waitClientDisconnect := make(chan struct{})
 	handlerFactory := simplefixgo.NewAcceptorHandlerFactory(fixgen.FieldMsgType, 10)
-	server := simplefixgo.NewAcceptor(listener, handlerFactory, func(handler simplefixgo.AcceptorHandler) {
+	server := simplefixgo.NewAcceptor(listener, handlerFactory, time.Second*5, func(handler simplefixgo.AcceptorHandler) {
 		acceptorSession, err := session.NewAcceptorSession(
 			&pseudoGeneratedOpts,
 			handler,
@@ -662,7 +663,7 @@ func TestInterruptHandling(t *testing.T) {
 	}
 
 	initiatorHandler := simplefixgo.NewInitiatorHandler(context.Background(), fixgen.FieldMsgType, 10)
-	client := simplefixgo.NewInitiator(conn, initiatorHandler, 10)
+	client := simplefixgo.NewInitiator(conn, initiatorHandler, 10, time.Second*5)
 
 	initiatorSession, err := session.NewInitiatorSession(
 		initiatorHandler,

--- a/tests/initiator.go
+++ b/tests/initiator.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"testing"
+	"time"
+
 	simplefixgo "github.com/b2broker/simplefix-go"
 	"github.com/b2broker/simplefix-go/fix"
 	"github.com/b2broker/simplefix-go/session"
 	fixgen "github.com/b2broker/simplefix-go/tests/fix44"
-	"net"
-	"testing"
-	"time"
 )
 
 func RunNewInitiator(addr string, t *testing.T, settings *session.LogonSettings) (s *session.Session, handler *simplefixgo.DefaultHandler) {
@@ -21,7 +22,7 @@ func RunNewInitiator(addr string, t *testing.T, settings *session.LogonSettings)
 	}
 
 	handler = simplefixgo.NewInitiatorHandler(context.Background(), fixgen.FieldMsgType, 10)
-	client := simplefixgo.NewInitiator(conn, handler, 10)
+	client := simplefixgo.NewInitiator(conn, handler, 10, time.Minute*50)
 
 	s, err = session.NewInitiatorSession(
 		handler,


### PR DESCRIPTION
There is a problem with FIX-servers that may stop reading msgs without TCP-connection disconnect. 
We shoud add SetWriteDeadline to our conn to prevent such problems.
