### PR TITLE
feat: buffered message-to-bytes convert

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,17 +11,20 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: golangci/golangci-lint-action@v2
+      - uses: actions/checkout@v4
+      - uses: golangci/golangci-lint-action@v4
+        with:
+          version: latest
+          config: .golangci.yml  # Явно указываем конфиг
 
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.16
+          go-version: 1.18
 
       - name: Unit tests
         run: go test -race ./...

--- a/acceptor.go
+++ b/acceptor.go
@@ -33,6 +33,7 @@ type AcceptorHandler interface {
 	CloseErrorChan()
 	Send(message SendingMessage) error
 	SendBatch(messages []SendingMessage) error
+	SendBuffered(message SendingMessage) error
 	SendRaw(data []byte) error
 	RemoveIncomingHandler(msgType string, id int64) (err error)
 	RemoveOutgoingHandler(msgType string, id int64) (err error)

--- a/fix/buffer/buffer.go
+++ b/fix/buffer/buffer.go
@@ -1,0 +1,39 @@
+package buffer
+
+import "bytes"
+
+type MessageByteBuffers struct {
+	msgBuffer    *bytes.Buffer
+	bodyBuffer   *bytes.Buffer
+	typeBuffer   *bytes.Buffer
+	headerBuffer *bytes.Buffer
+}
+
+func NewMessageByteBuffers(size int) *MessageByteBuffers {
+	return &MessageByteBuffers{
+		typeBuffer:   bytes.NewBuffer(make([]byte, 0, 5)), // 35=AA
+		msgBuffer:    bytes.NewBuffer(make([]byte, 0, size)),
+		bodyBuffer:   bytes.NewBuffer(make([]byte, 0, size)),
+		headerBuffer: bytes.NewBuffer(make([]byte, 0, size)),
+	}
+}
+
+func (m *MessageByteBuffers) Reset() {
+	m.msgBuffer.Reset()
+	m.bodyBuffer.Reset()
+	m.typeBuffer.Reset()
+	m.headerBuffer.Reset()
+}
+
+func (m *MessageByteBuffers) GetMessageBuffer() *bytes.Buffer {
+	return m.msgBuffer
+}
+func (m *MessageByteBuffers) GetBodyBuffer() *bytes.Buffer {
+	return m.bodyBuffer
+}
+func (m *MessageByteBuffers) GetHeaderBuffer() *bytes.Buffer {
+	return m.headerBuffer
+}
+func (m *MessageByteBuffers) GetTypeBuffer() *bytes.Buffer {
+	return m.typeBuffer
+}

--- a/fix/component.go
+++ b/fix/component.go
@@ -1,6 +1,7 @@
 package fix
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 )
@@ -63,6 +64,32 @@ func (c *Component) ToBytes() []byte {
 	}
 
 	return joinBody(msg...)
+}
+func (c *Component) IsEmpty() bool {
+	for _, item := range c.items {
+		if !item.IsEmpty() {
+			return false
+		}
+	}
+	return true
+}
+func (c *Component) WriteBytes(writer *bytes.Buffer) bool {
+	addDelimeter := false
+	written := false
+	for i, item := range c.items {
+		if !item.IsEmpty() && addDelimeter {
+			_ = writer.WriteByte(DelimiterChar)
+			addDelimeter = false
+		}
+		if item.WriteBytes(writer) {
+			written = true
+			if i <= len(c.items)-1 {
+				addDelimeter = true
+			}
+		}
+	}
+
+	return written
 }
 
 // Get returns a specific component item identified by its sequence number.

--- a/fix/convertor.go
+++ b/fix/convertor.go
@@ -1,0 +1,34 @@
+package fix
+
+import (
+	"sync"
+
+	"github.com/b2broker/simplefix-go/fix/buffer"
+)
+
+type MessageByteConverter struct {
+	pool sync.Pool
+}
+
+func NewMessageByteConverter(bufferSize int) *MessageByteConverter {
+	b := &MessageByteConverter{
+		pool: sync.Pool{
+			New: func() interface{} {
+				return buffer.NewMessageByteBuffers(bufferSize)
+			},
+		},
+	}
+	return b
+}
+
+type ConvertableMessage interface {
+	ToBytesBuffered(buffers *buffer.MessageByteBuffers) ([]byte, error)
+}
+
+func (m *MessageByteConverter) ConvertToBytes(message ConvertableMessage) ([]byte, error) {
+	buffers := m.pool.Get().(*buffer.MessageByteBuffers)
+	buffers.Reset()
+	defer m.pool.Put(buffers)
+
+	return message.ToBytesBuffered(buffers)
+}

--- a/fix/convertor_test.go
+++ b/fix/convertor_test.go
@@ -1,0 +1,70 @@
+package fix
+
+import (
+	"bytes"
+	"math/rand"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMessageByteConverter_ConvertToBytes(t *testing.T) {
+	conv := NewMessageByteConverter(100)
+	msg := NewMessage("8", "9", "10", "35", "FIX4.4", "A").
+		SetHeader(NewComponent(NewKeyValue("49", NewString("test")), NewKeyValue("56", NewString("test")))).
+		SetBody(NewKeyValue("100", NewString("test"))).
+		SetTrailer(NewComponent())
+
+	expected := []byte(`8=FIX4.49=3035=A49=test56=test100=test10=023`)
+	b, err := conv.ConvertToBytes(msg)
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+	if !bytes.Equal(expected, b) {
+		t.Fatalf("Expected %v, got %v", expected, string(b))
+	}
+}
+
+func TestMessageByteConverter_Concurrent(t *testing.T) {
+	conv := NewMessageByteConverter(100)
+	requests := make(chan int, 100)
+	wg := sync.WaitGroup{}
+	workers := 100
+
+	for workerID := 0; workerID < workers; workerID++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			workerKey := strconv.Itoa(workerID)
+			for i := range requests {
+				time.Sleep(time.Duration(rand.Int31n(10)) * time.Millisecond)
+				key := strconv.Itoa(i)
+				msg := NewMessage("8", "9", "10", "35", "FIX4.4", "A").
+					SetHeader(NewComponent(NewKeyValue("worker", NewString(workerKey)), NewKeyValue("messageID", NewString(key)))).
+					SetBody(NewKeyValue("100", NewString("test"))).
+					SetTrailer(NewComponent())
+				expected := []byte(`8=FIX4.49=3035=Aworker=` + workerKey + `messageID=` + key + `100=test10=023`)
+				b, err := conv.ConvertToBytes(msg)
+				if err != nil {
+					t.Errorf("Error: %s", err)
+				}
+				// here we replace length and checksum to ignore them
+				bb := bytes.Split(b, []byte{1})
+				expectedb := bytes.Split(expected, []byte{1})
+				bb[1] = expectedb[1]
+				bb[len(bb)-2] = expectedb[len(expectedb)-2]
+				b = bytes.Join(bb, []byte{1})
+				if !bytes.Equal(expected, b) {
+					t.Errorf("Expected %v,\n got %v", bb, expectedb)
+				}
+			}
+		}(workerID)
+	}
+
+	for i := 0; i < workers*100; i++ {
+		requests <- i
+	}
+	close(requests)
+	wg.Wait()
+}

--- a/fix/encoding/unmarshaler.go
+++ b/fix/encoding/unmarshaler.go
@@ -3,9 +3,10 @@ package encoding
 import (
 	"bytes"
 	"fmt"
+	"reflect"
+
 	"github.com/b2broker/simplefix-go/fix"
 	"github.com/b2broker/simplefix-go/session/messages"
-	"reflect"
 )
 
 type Validator interface {
@@ -213,7 +214,7 @@ func validateRaw(msg messages.Builder, d []byte, strict bool) error {
 		)
 	}
 
-	checkSum := fix.CalcCheckSum(d[:offset+length-1])
+	checkSum := fix.CalcCheckSumOptimized(d[:offset+length-1])
 
 	if !bytes.Equal(cs.Load().ToBytes(), checkSum) {
 		return fmt.Errorf(

--- a/fix/generator.go
+++ b/fix/generator.go
@@ -19,14 +19,10 @@ const (
 
 var Delimiter = []byte{1}
 
+const DelimiterChar = 1
+
 func joinBody(values ...[]byte) []byte {
 	return bytes.Join(values, Delimiter)
-}
-
-func makeTagValue(tag string, value []byte) []byte {
-	return bytes.Join([][]byte{
-		[]byte(tag), value,
-	}, []byte{61})
 }
 
 // nolint
@@ -49,4 +45,23 @@ func CalcCheckSum(body []byte) []byte {
 	sum += int(byte(1))
 
 	return []byte(fmt.Sprintf("%03s", strconv.Itoa(sum%256)))
+}
+
+func CalcCheckSumOptimized(bytes []byte) []byte {
+	var sum int
+	for _, b := range bytes {
+		sum += int(b)
+	}
+	sum += int(byte(1))
+	n := sum % 256
+	return []byte{byte('0' + n/100), byte('0' + (n/10)%10), byte('0' + n%10)}
+}
+
+func CalcCheckSumOptimizedFromBuffer(buffer *bytes.Buffer) []byte {
+	var sum int
+	for _, b := range buffer.Bytes() {
+		sum += int(b)
+	}
+	n := (sum + int(byte(1))) % 256
+	return []byte{byte('0' + n/100), byte('0' + (n/10)%10), byte('0' + n%10)}
 }

--- a/fix/generator_test.go
+++ b/fix/generator_test.go
@@ -1,0 +1,23 @@
+package fix
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestCalcCheckSum(t *testing.T) {
+	cases := [][]byte{
+		[]byte("8=FIX.4.2|9="),
+		[]byte("8=FIX.4.2|9=0"),
+		[]byte("8=FIX.4.2|9=0|"),
+		[]byte(""),
+		nil,
+	}
+	for _, c := range cases {
+		t.Run(string(c), func(t *testing.T) {
+			if !bytes.Equal(CalcCheckSumOptimized(c), CalcCheckSum(c)) {
+				t.Fatalf("CalcCheckSumOptimized %s != CalcCheckSum %s", CalcCheckSumOptimized(c), CalcCheckSum(c))
+			}
+		})
+	}
+}

--- a/fix/group.go
+++ b/fix/group.go
@@ -1,6 +1,7 @@
 package fix
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 )
@@ -60,6 +61,36 @@ func (g *Group) ToBytes() []byte {
 		}
 	}
 	return joinBody(msg...)
+}
+
+// always have size tag
+func (g *Group) IsEmpty() bool {
+	return false
+}
+
+func (g *Group) WriteBytes(writer *bytes.Buffer) bool {
+
+	if len(g.items) == 0 {
+		return false
+	}
+	intVal := NewInt(len(g.items))
+	NewKeyValue(g.noTag, intVal).WriteBytes(writer)
+
+	_ = writer.WriteByte(DelimiterChar)
+
+	addDelimeter := false
+	for i, item := range g.items {
+		if !item.IsEmpty() && addDelimeter {
+			_ = writer.WriteByte(DelimiterChar)
+			addDelimeter = false
+		}
+		if item.WriteBytes(writer) {
+			if i <= len(g.items)-1 {
+				addDelimeter = true
+			}
+		}
+	}
+	return true
 }
 
 // AddEntry adds a new entry with the same list of tags as in a specified group.

--- a/fix/group_test.go
+++ b/fix/group_test.go
@@ -118,6 +118,17 @@ func TestGroup_AddItem(t *testing.T) {
 		t.Log(len(res), string(res))
 		t.Fatalf("message length is not equal")
 	}
+
+	converter := NewMessageByteConverter(200)
+	res, err = converter.ConvertToBytes(msg)
+	if err != nil {
+		t.Fatalf("could not marshal message: %s", err)
+	}
+	if !bytes.Equal(testMsg, res) {
+		t.Log(len(testMsg), string(testMsg))
+		t.Log(len(res), string(res))
+		t.Fatalf("message length is not equal")
+	}
 }
 
 func TestGroup_Parse(t *testing.T) {

--- a/fix/types.go
+++ b/fix/types.go
@@ -1,7 +1,10 @@
 package fix
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 )
@@ -10,6 +13,7 @@ import (
 type Value interface {
 	// ToBytes returns a byte representation of a field value.
 	ToBytes() []byte
+	WriteBytes(writer *bytes.Buffer) bool
 
 	// FromBytes parses values stored in a byte array.
 	FromBytes([]byte) error
@@ -20,8 +24,11 @@ type Value interface {
 	// String returns a string representation of a value.
 	String() string
 
-	// IsNull is used to check whether a field value is empty.
+	// IsNull is used to check whether a field value is not filled
 	IsNull() bool
+
+	// IsNull is used to check whether a field value is empty.
+	IsEmpty() bool
 
 	// Set replaces a specified field value with a value of a corresponding type.
 	Set(d interface{}) error
@@ -43,6 +50,11 @@ func (v *Raw) ToBytes() []byte {
 	return v.value
 }
 
+func (v *Raw) WriteBytes(writer *bytes.Buffer) bool {
+	_, _ = writer.Write(v.value)
+	return true
+}
+
 func (v *Raw) FromBytes(d []byte) (err error) {
 	v.value = d
 	return nil
@@ -51,7 +63,9 @@ func (v *Raw) FromBytes(d []byte) (err error) {
 func (v *Raw) IsNull() bool {
 	return v.value == nil
 }
-
+func (v *Raw) IsEmpty() bool {
+	return v.value == nil
+}
 func (v *Raw) Value() interface{} {
 	return v.value
 }
@@ -102,11 +116,20 @@ func (v *String) ToBytes() []byte {
 	}
 	return []byte(v.value)
 }
+func (v *String) WriteBytes(writer *bytes.Buffer) bool {
+	if !v.valid || v.value == "" {
+		return false
+	}
+	_, _ = writer.WriteString(v.value)
+	return true
+}
 
 func (v *String) IsNull() bool {
 	return !v.valid
 }
-
+func (v *String) IsEmpty() bool {
+	return !v.valid || v.value == ""
+}
 func (v *String) Value() interface{} {
 	return v.value
 }
@@ -134,10 +157,13 @@ type Int struct {
 }
 
 func NewInt(value int) *Int {
-	return &Int{value: value, valid: true}
+	return &Int{valid: true, value: value}
 }
 
 func (v *Int) IsNull() bool {
+	return !v.valid
+}
+func (v *Int) IsEmpty() bool {
 	return !v.valid
 }
 
@@ -171,7 +197,7 @@ func (v *Int) FromBytes(d []byte) (err error) {
 	}
 
 	v.valid = true
-	v.value, err = strconv.Atoi(string(d))
+	v.value, err = bytesToInt(d)
 
 	return err
 }
@@ -180,7 +206,14 @@ func (v *Int) ToBytes() []byte {
 	if !v.valid {
 		return nil
 	}
-	return []byte(strconv.Itoa(v.value))
+	return intToBytes(v.value)
+}
+func (v *Int) WriteBytes(writer *bytes.Buffer) bool {
+	if !v.valid {
+		return false
+	}
+	_, _ = writer.Write(intToBytes(v.value))
+	return true
 }
 
 // Uint is a structure used for converting values to the uint64 type.
@@ -190,7 +223,7 @@ type Uint struct {
 }
 
 func NewUint(value uint64) *Uint {
-	return &Uint{value: value}
+	return &Uint{value: value, valid: true}
 }
 
 // Set parses and assigns the field value stored as a uint64 number.
@@ -212,7 +245,9 @@ func (v *Uint) Set(d interface{}) error {
 func (v *Uint) IsNull() bool {
 	return !v.valid
 }
-
+func (v *Uint) IsEmpty() bool {
+	return !v.valid
+}
 func (v *Uint) FromBytes(d []byte) (err error) {
 	if d == nil {
 		v.valid = false
@@ -220,7 +255,7 @@ func (v *Uint) FromBytes(d []byte) (err error) {
 	}
 
 	v.valid = true
-	v.value, err = strconv.ParseUint(string(d), 10, 64)
+	v.value, err = bytesToUint(d)
 
 	return err
 }
@@ -237,7 +272,14 @@ func (v *Uint) ToBytes() []byte {
 	if !v.valid {
 		return nil
 	}
-	return []byte(strconv.FormatUint(v.value, 10))
+	return uintToBytes(v.value)
+}
+func (v *Uint) WriteBytes(writer *bytes.Buffer) bool {
+	if !v.valid {
+		return false
+	}
+	_, _ = writer.Write(uintToBytes(v.value))
+	return true
 }
 
 // Float is a structure used for converting values to the float64 type.
@@ -248,13 +290,15 @@ type Float struct {
 }
 
 func NewFloat(value float64) *Float {
-	return &Float{value: value}
+	return &Float{value: value, valid: true}
 }
 
 func (v *Float) IsNull() bool {
 	return !v.valid
 }
-
+func (v *Float) IsEmpty() bool {
+	return !v.valid
+}
 func (v *Float) Value() interface{} {
 	return v.value
 }
@@ -267,7 +311,7 @@ func (v *Float) FromBytes(d []byte) (err error) {
 
 	v.valid = true
 	v.source = d
-	v.value, err = strconv.ParseFloat(string(d), 64)
+	v.value, err = bytesToFloat(d)
 
 	return err
 }
@@ -279,9 +323,20 @@ func (v *Float) ToBytes() []byte {
 	if v.source != nil {
 		return v.source
 	}
-	return []byte(strconv.FormatFloat(v.value, 'f', -1, 64))
+	return floatToBytes(v.value)
 }
+func (v *Float) WriteBytes(writer *bytes.Buffer) bool {
+	if !v.valid {
+		return false
+	}
 
+	if v.source != nil {
+		_, _ = writer.Write(v.source)
+	} else {
+		_, _ = writer.Write(strconv.AppendFloat(make([]byte, 0, 64), v.value, 'f', -1, 64))
+	}
+	return true
+}
 func (v *Float) String() string {
 	return fmt.Sprintf("%f", v.value)
 }
@@ -331,6 +386,9 @@ func (v *Time) Set(d interface{}) error {
 func (v *Time) IsNull() bool {
 	return !v.valid
 }
+func (v *Time) IsEmpty() bool {
+	return !v.valid
+}
 
 func (v *Time) Value() interface{} {
 	return v.value
@@ -340,9 +398,15 @@ func (v *Time) ToBytes() []byte {
 	if !v.valid {
 		return nil
 	}
-	return []byte(v.value.Format(TimeLayout)) // TODO: set layout outside.
+	return timeToBytes(v.value)
 }
-
+func (v *Time) WriteBytes(writer *bytes.Buffer) bool {
+	if !v.valid {
+		return false
+	}
+	_, _ = writer.Write(timeToBytes(v.value))
+	return true
+}
 func (v *Time) FromBytes(d []byte) (err error) {
 	if d == nil {
 		v.valid = false
@@ -360,9 +424,12 @@ func (v *Time) String() string {
 }
 
 const (
-	True  = "Y"
-	False = "N"
+	True  = 'Y'
+	False = 'N'
 )
+
+var trueByte = []byte{True}
+var falseByte = []byte{False}
 
 // Bool is a structure used for converting Boolean values.
 type Bool struct {
@@ -376,9 +443,21 @@ func (v *Bool) ToBytes() []byte {
 	}
 
 	if v.value {
-		return []byte(True)
+		return trueByte
 	}
-	return []byte(False)
+	return falseByte
+}
+func (v *Bool) WriteBytes(writer *bytes.Buffer) bool {
+	if !v.valid {
+		return false
+	}
+
+	if v.value {
+		_, _ = writer.Write(trueByte)
+	} else {
+		_, _ = writer.Write(falseByte)
+	}
+	return true
 }
 
 func (v *Bool) FromBytes(d []byte) error {
@@ -388,7 +467,7 @@ func (v *Bool) FromBytes(d []byte) error {
 	}
 
 	v.valid = true
-	v.value = string(d) == True
+	v.value = len(d) > 0 && d[0] == True
 
 	return nil
 }
@@ -403,12 +482,15 @@ func (v *Bool) String() string {
 	}
 
 	if v.value {
-		return True
+		return string(True)
 	}
-	return False
+	return string(False)
 }
 
 func (v *Bool) IsNull() bool {
+	return !v.valid
+}
+func (v *Bool) IsEmpty() bool {
 	return !v.valid
 }
 
@@ -426,4 +508,141 @@ func (v *Bool) Set(d interface{}) error {
 	}
 
 	return fmt.Errorf("could not convert %s to %s", d, "Boolean")
+}
+
+func bytesToUint(d []byte) (uint64, error) {
+	if len(d) == 0 {
+		return 0, errors.New("invalid input: empty byte slice")
+	}
+	var result uint64
+	for i := 0; i < len(d); i++ {
+		c := d[i]
+		if c < '0' || c > '9' {
+			return 0, errors.New("invalid input: non-numeric character")
+		}
+		digit := uint64(c - '0')
+		if result > math.MaxUint64/10 || (result == math.MaxUint64/10 && digit > math.MaxUint64%10) {
+			return 0, errors.New("overflow: value too large for uint64")
+		}
+		result = result*10 + digit
+	}
+	return result, nil
+}
+func uintToBytes(value uint64) []byte {
+	return strconv.AppendUint(make([]byte, 0, 20), value, 10)
+}
+
+// not working with negative values
+func timeToBytes(t time.Time) []byte {
+	year, month, day := t.Date()
+	if year < 0 {
+		year = 0
+	}
+	hour, minute, second := t.Clock()
+	milli := t.Nanosecond() / 1e6
+	return []byte{byte('0' + year/1000),
+		byte('0' + (year/100)%10),
+		byte('0' + (year/10)%10),
+		byte('0' + year%10),
+
+		byte('0' + (month/10)%10),
+		byte('0' + month%10),
+
+		byte('0' + (day/10)%10),
+		byte('0' + day%10),
+		'-',
+		byte('0' + (hour/10)%10),
+		byte('0' + hour%10),
+		':',
+		byte('0' + (minute/10)%10),
+		byte('0' + minute%10),
+		':',
+		byte('0' + (second/10)%10),
+		byte('0' + second%10),
+		'.',
+		byte('0' + milli/100),
+		byte('0' + (milli/10)%10),
+		byte('0' + milli%10)}
+}
+
+func floatToBytes(f float64) []byte {
+	if f == 0 {
+		return []byte{'0'}
+	}
+	return strconv.AppendFloat(make([]byte, 0, 64), f, 'f', -1, 64)
+}
+func bytesToFloat(data []byte) (float64, error) {
+	// Проверяем на пустой ввод
+	if len(data) == 0 {
+		return 0, errors.New("invalid input: empty data")
+	}
+
+	var (
+		result     float64
+		sign       float64 = 1
+		decimalPos int     = -1
+	)
+
+	// Обработка отрицательных чисел
+	if data[0] == '-' {
+		sign = -1
+		data = data[1:]
+	}
+	if len(data) == 1 && data[0] == '.' {
+		return 0, errors.New("invalid input: single decimal point")
+	}
+
+	for i, c := range data {
+		if c == '.' {
+			if decimalPos != -1 {
+				return 0, errors.New("invalid input: multiple decimal points")
+			}
+			decimalPos = i
+			continue
+		}
+
+		if c < '0' || c > '9' {
+			return 0, errors.New("invalid input: non-numeric character")
+		}
+
+		result = result*10 + float64(c-'0')
+	}
+
+	// Применяем корректировку для дробной части
+	if decimalPos != -1 {
+		scale := math.Pow10(len(data) - decimalPos - 1)
+		result /= scale
+	}
+
+	return result * sign, nil
+}
+
+func bytesToInt(d []byte) (int, error) {
+	if len(d) == 0 {
+		return 0, errors.New("invalid input: empty byte slice")
+	}
+
+	var result int
+	var sign int = 1
+	start := 0
+
+	if d[0] == '-' {
+		sign = -1
+		start = 1
+	} else if d[0] == '+' {
+		start = 1
+	}
+
+	for i := start; i < len(d); i++ {
+		c := d[i]
+		if c < '0' || c > '9' {
+			return 0, errors.New("invalid input: non-numeric character")
+		}
+		result = result*10 + int(c-'0')
+	}
+
+	return result * sign, nil
+}
+func intToBytes(value int) []byte {
+	return strconv.AppendInt(make([]byte, 0, 20), int64(value), 10)
 }

--- a/fix/types.go
+++ b/fix/types.go
@@ -628,14 +628,9 @@ func bytesToFloat(s []byte) (float64, error) {
 	f := float64(d)
 	if s[0] != '.' || l == 1 {
 		if i <= j {
-			ss := s[i:]
-			if bytes.HasPrefix(ss, []byte{'+'}) {
-				ss = ss[1:]
-			}
 			return 0, errors.New("invalid syntax: unparsable tail left")
 		}
 		if i >= l {
-			// Fast path - just integer.
 			if minus {
 				return -f, nil
 			}

--- a/fix/types.go
+++ b/fix/types.go
@@ -584,6 +584,7 @@ func init() {
 	}
 }
 
+// inspired by https://github.com/valyala/fastjson/blob/6dae91c8e11a7fa6a257a550b75cba53ab81693e/fastfloat/parse.go#L203
 func bytesToFloat(s []byte) (float64, error) {
 	l := uint(len(s))
 	if l == 0 {

--- a/fix/types_test.go
+++ b/fix/types_test.go
@@ -184,8 +184,10 @@ func TestFormatToFloatStrConv(t *testing.T) {
 		{[]byte("3.402823466385288598e+10"), 3.402823466385288598e+10, "", ""},
 		{[]byte("3.40282346638528859811704183484516925440e+10"), 3.40282346638528859811704183484516925440e+10, "", ""},
 		{[]byte("3.40282346638528859811704183484516925440e+38"), math.MaxFloat32, "", ""},
+		{[]byte("1.401298464324817e-45"), math.SmallestNonzeroFloat32, "", ""},
 		{[]byte("1.79769313486231570814527423731704356798070e+308"), math.MaxFloat64, "", ""},
-		{[]byte("3.40282346638528859811704183484516925440e+300"), 3.40282346638528859811704183484516925440e+300, "", ""},
+		{[]byte("1.79769313486231570814527423731704356798070e-308"), 1.79769313486231570814527423731704356798070e-308, "", ""},
+		{[]byte("5e-324"), math.SmallestNonzeroFloat64, "", ""},
 		{[]byte("179769313486231574112351123123"), 179769313486231574112351123123, "", ""},
 		{[]byte(""), 0,
 			"strconv.ParseFloat: parsing \"\": invalid syntax",
@@ -216,7 +218,7 @@ func TestFormatToFloatStrConv(t *testing.T) {
 
 	tstr := ""
 	for _, c := range vv {
-		t.Run(fmt.Sprintf("float case %+v", c.e), func(t *testing.T) {
+		t.Run(fmt.Sprintf("float case %s", c.v), func(t *testing.T) {
 			str := fmt.Sprintf("%s,", string(c.v))
 			v, err := strconv.ParseFloat(string(c.v), 64)
 			if v != c.e {

--- a/fix/types_test.go
+++ b/fix/types_test.go
@@ -27,7 +27,6 @@ func BenchmarkFormatFloat(b *testing.B) {
 	}
 }
 
-// BenchmarkFormatToFloat-24   a         			 7569190	         105.0 ns/op
 // BenchmarkFormatToFloat-24   0         			 540723948	         2.209 ns/op
 // BenchmarkFormatToFloat-24   123         			 439286569	         2.725 ns/op
 // BenchmarkFormatToFloat-24   0.12345678  			 162624674	         7.719 ns/op
@@ -36,7 +35,7 @@ func BenchmarkFormatFloat(b *testing.B) {
 // BenchmarkFormatToFloat-24   a					 58579447	         15.25 ns/op
 // BenchmarkFormatToFloat-24   12312312312.131212212 123302217	         39.66 ns/op
 func BenchmarkFormatToFloat(b *testing.B) {
-	v := []byte("12312312312.131212212")
+	v := []byte("я")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = bytesToFloat(v)

--- a/initiator.go
+++ b/initiator.go
@@ -18,6 +18,7 @@ type InitiatorHandler interface {
 	StopWithError(err error)
 	CloseErrorChan()
 	Send(message SendingMessage) error
+	SendBuffered(message SendingMessage) error
 	Context() context.Context
 	Stop()
 }

--- a/session/messages/builder.go
+++ b/session/messages/builder.go
@@ -1,6 +1,9 @@
 package messages
 
-import "github.com/b2broker/simplefix-go/fix"
+import (
+	"github.com/b2broker/simplefix-go/fix"
+	"github.com/b2broker/simplefix-go/fix/buffer"
+)
 
 type Builder interface {
 	Items() fix.Items
@@ -11,6 +14,7 @@ type Builder interface {
 	BeginString() *fix.KeyValue
 	MsgType() string
 	ToBytes() ([]byte, error)
+	ToBytesBuffered(buffers *buffer.MessageByteBuffers) ([]byte, error)
 	BeginStringTag() string
 	BodyLengthTag() string
 	CheckSumTag() string

--- a/session/messages/contstants.go
+++ b/session/messages/contstants.go
@@ -1,5 +1,9 @@
 package messages
 
+import (
+	"github.com/b2broker/simplefix-go/fix/buffer"
+)
+
 // Tags is a structure specifying the required tags for session pipelines.
 type Tags struct {
 	MsgType         int
@@ -28,4 +32,5 @@ type Message interface {
 	HeaderBuilder() HeaderBuilder
 	MsgType() string
 	ToBytes() ([]byte, error)
+	ToBytesBuffered(buffers *buffer.MessageByteBuffers) ([]byte, error)
 }

--- a/session/messages/mock_message.go
+++ b/session/messages/mock_message.go
@@ -1,5 +1,9 @@
 package messages
 
+import (
+	"github.com/b2broker/simplefix-go/fix/buffer"
+)
+
 type MockMessage struct {
 	Type string
 	Data []byte
@@ -19,5 +23,8 @@ func (m MockMessage) MsgType() string {
 }
 
 func (m MockMessage) ToBytes() ([]byte, error) {
+	return m.Data, m.Err
+}
+func (m MockMessage) ToBytesBuffered(_ *buffer.MessageByteBuffers) ([]byte, error) {
 	return m.Data, m.Err
 }


### PR DESCRIPTION
New message method ToBytesBuffered(buffers [4]*bytes.Buffer) ([]byte, error) allows effectively convert messages to bytes using four bytes buffers, wich could be combined with sync.Pool to reuse allocated memory.
Givan buffers clearing via Reset() before usage at the begin of Prepare method call.

// BenchmarkMessage_Prepare-24    	                 1263648	       982.7 ns/op
// BenchmarkMessage_PrepareBuffered-24    	 5937844	       198.1 ns/op

As we can see on this benchmark results, message conversion could be speeded up x5

Also mesage field types being speeded up by usage ultra-optimized methods of data conversion from/to byte array.